### PR TITLE
Make ldtkgo.Open work when compiling for web

### DIFF
--- a/file_js.go
+++ b/file_js.go
@@ -1,0 +1,30 @@
+//go:build js
+
+package ldtkgo
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+)
+
+type file struct {
+	*bytes.Reader
+}
+
+func (f *file) Close() error {
+	return nil
+}
+
+func OpenFile(path string) (FileReader, error) {
+	res, err := http.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	f := &file{bytes.NewReader(body)}
+	return f, nil
+}

--- a/file_notjs.go
+++ b/file_notjs.go
@@ -1,0 +1,17 @@
+//go:build !js
+
+package ldtkgo
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// OpenFile opens a file and returns a stream for its data.
+//
+// The path parts should be separated with slash '/' on any environments.
+//
+// Note that this doesn't work on mobiles.
+func OpenFile(path string) (FileReader, error) {
+	return os.Open(filepath.FromSlash(path))
+}

--- a/ldtkgo.go
+++ b/ldtkgo.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"image"
 	"image/color"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
@@ -359,22 +360,31 @@ func (project *Project) TilesetByIdentifier(identifier string) *Tileset {
 	return nil
 }
 
+type FileReader interface {
+	io.ReadSeeker
+	io.Closer
+}
+
 // Open loads the LDtk project from the filepath specified. Returns the Project and an error should the loading process fail (unable to find the file, unable to deserialize the JSON).
 func Open(filepath string) (*Project, error) {
 
 	var project *Project
 
-	var bytes []byte
+	var fileReader FileReader
 	var err error
 
-	bytes, err = ioutil.ReadFile(filepath)
+	fileReader, err = OpenFile(filepath)
+
+	var bytes []byte
+	if err == nil {
+		bytes, err = ioutil.ReadAll(fileReader)
+	}
 
 	if err == nil {
 		project, err = Read(bytes)
 	}
 
 	return project, err
-
 }
 
 // Read reads the LDtk project using the specified slice of bytes. Returns the Project and an error should there be an error in the loading process (unable to properly deserialize the JSON).


### PR DESCRIPTION
Currently `ldtkgo.Open` tries to find the `filepath` on the local disk, this means that it doesn't work on a go project compiled for web. This PR extracts the `Open` logic to 2 separate files, one gets included in the build when building for js and one when not, this ensures that files can always be properly loaded

An easy way to test this is to just run the `ldtkgo/example` using [github.com/hajimehoshi/wasmserve](https://github.com/hajimehoshi/wasmserve):

```
cd examples
wasmserve . 

# open http://localhost:8080/ on browser
```


## Some questions

I've pretty much taken these files from `ebitenutils`:

- https://github.com/hajimehoshi/ebiten/blob/main/ebitenutil/file_notjs.go
- https://github.com/hajimehoshi/ebiten/blob/main/ebitenutil/file_js.go

Do you think it's necessary to include the original license header and worry that ebitenutils is Apache2 while ldtkgo is MIT? Maybe just adding a comment we took them from there should be enough?

Another idea would be to remove this _dynamic loader_ and instead just allow users to provide the bytes directly. This would allow things like embedding the ldtk map directly in the binary.