### PR TITLE
fix: add entitiy definition support

### DIFF
--- a/ldtkgo.go
+++ b/ldtkgo.go
@@ -98,6 +98,8 @@ type EntityDefinition struct {
 	Height     int       `json:"height"`     // Height of the Entity in pixels
 	Tags       []string  `json:"tags"`       // Tags (categories) assigned to the Entity
 	TileRect   *TileRect `json:"tileRect"`
+	PivotX     float32   `json:"pivotX"`
+	PivotY     float32   `json:"pivotY"`
 }
 
 // An Entity represents an Entity as placed in the LDtk level.

--- a/ldtkgo.go
+++ b/ldtkgo.go
@@ -408,7 +408,7 @@ func (project *Project) TilesetByIdentifier(identifier string) *Tileset {
 	return nil
 }
 
-// EntityByUUID returns the Entity by unique identifier specified, or nil if entity isn't found
+// EntityByIID returns the Entity by unique identifier specified, or nil if entity isn't found
 func (project *Project) EntityByIID(iid string) *Entity {
 	for _, level := range project.Levels {
 		for _, layer := range level.Layers {
@@ -422,7 +422,7 @@ func (project *Project) EntityByIID(iid string) *Entity {
 	return nil
 }
 
-// EntityByUUID returns the Entity by unique identifier specified, or nil if entity isn't found
+// EntityDefinitionByIdentifier returns the EntityDefinition by unique identifier specified, or nil if entity isn't found
 func (project *Project) EntityDefinitionByIdentifier(identifier string) *EntityDefinition {
 	for _, definition := range project.EntityDefinitions {
 		if definition.Identifier == identifier {


### PR DESCRIPTION
I want to use entity definitions to use entities, which are not placed/instantiated in layers, but are still managed by ldtk to use the tileset associated with this entity definition in my game code. 

My use case is a snake game, where the snake has no body parts in the beginning, therefore not placed in the ldtk world. But the body parts are still part of the tileset image of another ldtk entity, i.e., the head of the snake. Therefore I defined the body part as an entity, which this PR enables the usage of EntityDefinitions of ldtk projects. 

This PR should be seen as an initial support, because there are more fields in the ldtk project, which could be of valuable in a different use-case.

Some truncated example usage:

```go
func (ldtk LDtkProject) GetSpriteByDefinition(entityDefinition *ldtkgo.EntityDefinition) (*ebiten.Image, error) {
	return ldtk.GetSprite(entityDefinition.TileRect)
}

func (ldtk LDtkProject) GetSpriteByEntityInstance(entity *ldtkgo.Entity) (*ebiten.Image, error) {
	return ldtk.GetSprite(entity.TileRect)
}

func (ldtk LDtkProject) GetSprite(tileRect *ldtkgo.TileRect) (*ebiten.Image, error) {
	tileset, err := ldtk.Renderer.Loader.LoadImage(tileRect.Tileset.Path)
	t := tileRect
	subImageRect := image.Rect(t.X, t.Y, t.X+t.W, t.Y+t.H)
	sprite := tileset.SubImage(subImageRect).(*ebiten.Image)
	return sprite, err
}

entityDefinition := s.ldtkProject.Project.EntityDefinitionByIdentifier("SnakeBody")
sprite, err := s.ldtkProject.GetSpriteByDefinition(entityDefinition)
//error handling
factory.CreateBodyPart(s.ecs, sprite, snakeEntry)
```